### PR TITLE
Updates Es search implementation to use _source instead of fields

### DIFF
--- a/search/es/src/main/java/io/em2m/search/es/EsApi.kt
+++ b/search/es/src/main/java/io/em2m/search/es/EsApi.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package io.em2m.search.es
 
 import com.fasterxml.jackson.annotation.*
@@ -272,7 +274,8 @@ class EsScrollRequest(@JsonProperty("scroll_id") val scrollId: String,
 class EsSearchRequest(var from: Long = 0,
                       var size: Long = 50,
                       var query: EsQuery = EsMatchAllQuery(),
-                      var fields: List<String>? = null,
+                      @JsonProperty("_source")
+                      var source: List<String>? = null,
                       var aggs: EsAggs? = null,
                       var sort: List<Map<String, String>>? = mutableListOf(),
                       @JsonProperty("stored_fields")

--- a/search/es/src/main/java/io/em2m/search/es/RequestConverter.kt
+++ b/search/es/src/main/java/io/em2m/search/es/RequestConverter.kt
@@ -19,11 +19,7 @@ class RequestConverter(val objectMapper: ObjectMapper = jacksonObjectMapper(), v
         val aggs = convertAggs(request.aggs, request.params)
         val sort = convertSorts(request.sorts)
 
-        return when {
-            es6 -> EsSearchRequest(from, size, query, aggs = aggs, sort = sort, storedFields = fields)
-            else -> EsSearchRequest(from, size, query, fields, aggs, sort)
-        }
-
+        return EsSearchRequest(from = from, size = size, query = query, aggs = aggs, sort = sort, source = fields)
     }
 
     fun convertQuery(query: Query?, params: Map<String, Any>?): EsQuery = when (query) {

--- a/search/es/src/test/java/io/em2m/search/es/EsApiTest.kt
+++ b/search/es/src/test/java/io/em2m/search/es/EsApiTest.kt
@@ -80,16 +80,14 @@ class EsApiTest : FeatureTestBase() {
 
     @Test
     fun testFields() {
-        val request = if (FeatureTestBase.es6) {
-            EsSearchRequest(from = 0, size = 10, query = EsMatchAllQuery(), storedFields = listOf("id", "properties.time"))
-        } else {
-            EsSearchRequest(from = 0, size = 10, query = EsMatchAllQuery(), fields = listOf("id", "properties.time"))
-        }
+        val request = EsSearchRequest(from = 0, size = 10, query = EsMatchAllQuery(), source = listOf("id", "properties.time"))
         val result = esClient.search(index, type, request)
 
         Assert.assertEquals(46, result.hits.total)
         Assert.assertEquals(10, result.hits.hits.size)
-        Assert.assertEquals(2, result.hits.hits[0].fields?.values?.size)
+        val esHit: EsHit = result.hits.hits[0]
+        Assert.assertNotNull(esHit.source?.get("id"))
+        Assert.assertNotNull(esHit.source?.get("properties")?.get("time"))
     }
 
     @Test


### PR DESCRIPTION
Using _source field mappings instead of fields.  This provides us with the ability to fetch arrays (such as data.vid.state) geo shapes, and other non leaf fields.    The performance is pretty much identical against our data :)

