### PR TITLE
Adds custom charsets to requests and lambdas. Adds unit tests for exploding emojis.

### DIFF
--- a/actions/src/main/java/io/em2m/actions/lambda/LambdaRuntime.kt
+++ b/actions/src/main/java/io/em2m/actions/lambda/LambdaRuntime.kt
@@ -7,6 +7,7 @@ import io.em2m.actions.model.ActionProcessor
 import io.em2m.actions.model.MultipartData
 import io.em2m.problem.Problem
 import io.em2m.policy.model.Claims
+import io.em2m.utils.parseCharset
 import java.util.*
 
 open class LambdaRuntime(
@@ -22,10 +23,13 @@ open class LambdaRuntime(
         // TODO: Detect and pars MultiPart
         val multipart: MultipartData? = null
 
+        val contentType = request.contentType
+        val charset = parseCharset(contentType)
+
         val context = ActionContext(
                 actionName = "$actionPrefix:$actionName",
                 claims = Claims(),
-                inputStream = request.body?.toByteArray()?.inputStream() ?: byteArrayOf().inputStream(),
+                inputStream = request.body?.toByteArray(charset)?.inputStream() ?: byteArrayOf().inputStream(),
                 environment = env.toMutableMap(),
                 multipart = multipart,
                 response = response)

--- a/actions/src/test/java/io/em2m/actions/JacksonRequestTransformerTest.kt
+++ b/actions/src/test/java/io/em2m/actions/JacksonRequestTransformerTest.kt
@@ -35,10 +35,12 @@ class JacksonRequestTransformerTest {
             )
         )
 
+        val charset = Charsets.UTF_8
+
         val testContext = ActionContext(
             actionName = "TestService:TestAction",
             claims = Claims(),
-            inputStream = testRequest.body?.toByteArray()?.inputStream() ?: byteArrayOf().inputStream(),
+            inputStream = testRequest.body?.toByteArray(charset)?.inputStream() ?: byteArrayOf().inputStream(),
             response = LambdaResponse(),
             environment = mutableMapOf(
                 "ContentType" to "application/json"

--- a/utils/src/main/java/io/em2m/utils/regex.kt
+++ b/utils/src/main/java/io/em2m/utils/regex.kt
@@ -1,0 +1,9 @@
+package io.em2m.utils
+
+fun Regex.firstIncompleteMatch(baseString: String): String? {
+    return this.find(baseString)?.groupValues?.getOrNull(1)
+}
+
+fun Regex.firstIncompleteMatchOr(baseString: String, default: String): String {
+    return this.firstIncompleteMatch(baseString) ?: default
+}

--- a/utils/src/main/java/io/em2m/utils/request.kt
+++ b/utils/src/main/java/io/em2m/utils/request.kt
@@ -1,0 +1,16 @@
+package io.em2m.utils
+
+import java.nio.charset.Charset
+
+private val DEFAULT_CHARSET = Charsets.UTF_8
+private val CHARSET_REGEX = "(?i)charset\\s*=\\s*['\"]?([^;'\"]+)".toRegex()
+
+fun parseCharset(contentType: String?): Charset {
+    if (contentType == null) return DEFAULT_CHARSET
+    val charsetString = CHARSET_REGEX.firstIncompleteMatchOr(contentType, "UTF-8")
+    return try {
+        Charset.forName(charsetString)
+    } catch (_: Exception) {
+        DEFAULT_CHARSET
+    }
+}

--- a/utils/src/test/java/io/em2m/utils/CharsetTest.kt
+++ b/utils/src/test/java/io/em2m/utils/CharsetTest.kt
@@ -1,0 +1,63 @@
+package io.em2m.utils
+
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+
+class CharsetTest {
+
+    private fun brokenCode(characters: List<Char>): String {
+        val inputStream = characters.toString().byteInputStream()
+
+        val buffer = ByteArray(8192)
+        val outputStream = ByteArrayOutputStream()
+
+        inputStream.buffered().use { input ->
+            outputStream.use { output ->
+                var bytesRead: Int
+                while (input.read(buffer).also { bytesRead = it } != -1) {
+                    val sanitizedChunk = String(buffer, 0, bytesRead)
+                    output.write(sanitizedChunk.toByteArray())
+                }
+            }
+        }
+
+        return outputStream.toString()
+    }
+
+    private fun fixedCode(characters: List<Char>): String {
+        val charset = Charsets.UTF_8
+        val inputStream = characters.toString().byteInputStream(charset)
+        return inputStream.reader(charset).use { it.readText() }
+    }
+
+    @Test
+    fun `U+2019 Right Single Quotation Mark`() {
+        val characters = mutableListOf<Char>()
+        repeat(8191) { characters.add('a') }
+        // https://www.compart.com/en/unicode/U+2019
+        // Character represented as 3 bytes: 0xE2 0x80 0x99
+        characters.add('’')
+
+        val brokenRepresentation = brokenCode(characters)
+        val fixedRepresentation = fixedCode(characters)
+
+        assert('�' in brokenRepresentation)
+        assert('�' !in fixedRepresentation)
+    }
+
+    @Test
+    fun `U+2665 Heart Emoji`() {
+        val characters = mutableListOf<Char>()
+        repeat(8191) { characters.add('a') }
+        // https://www.compart.com/en/unicode/U+2665
+        // Character represented as 3 bytes: 0xE2 0x99 0xA5
+        characters.add('♥')
+
+        val brokenRepresentation = brokenCode(characters)
+        val fixedRepresentation = fixedCode(characters)
+
+        assert('�' in brokenRepresentation)
+        assert('�' !in fixedRepresentation)
+    }
+
+}


### PR DESCRIPTION
Newer unicode characters map to multiple bytes, so when you have a buffer of size 8192, and a special character is at the end of that buffer, the emoji can get chopped in half, leading to an unknown character appearing and being locked in subsequent requests.